### PR TITLE
Fix set hostname for FreeIPA domain

### DIFF
--- a/src/udsactor/linux/operations.py
+++ b/src/udsactor/linux/operations.py
@@ -205,7 +205,7 @@ def joinDomain(name: str, custom: typing.Optional[typing.Mapping[str, typing.Any
 
     if server_software == 'ipa':
         try:
-            hostname = getComputerName() + domain[domain.index('.'):]
+            hostname = f'{getComputerName().lower()}.{domain}'
             command = f'hostnamectl set-hostname {hostname}'
             subprocess.run(command, shell=True)
         except Exception as e:


### PR DESCRIPTION
If there are capital letters in the hostname of the machine then the machine does not join the domain. There is also a slight change in the domain name to change the hostname.