### PR TITLE
GitHub actions

### DIFF
--- a/.github/actor_managed.nsi
+++ b/.github/actor_managed.nsi
@@ -1,0 +1,33 @@
+!define VERSION 1.0.0
+
+Name "Actor Managed"
+OutFile "openUDS-Managed_Installer-${VERSION}.exe"
+InstallDir "$PROGRAMFILES\UDSActor"
+Page Directory
+Page InstFiles
+Section
+  SetOutPath $INSTDIR
+  File actor_client.exe
+  File actor_config.exe
+  File actor_service.exe
+
+  !define COMPANYNAME "OpenUDS"
+
+  !define appName "actor_service.exe"
+  !define displayName "UDS Actor Service"
+  !define serviceName "UDSActorService"
+
+  createDirectory "$SMPROGRAMS\${COMPANYNAME}"
+  createShortCut "$SMPROGRAMS\${COMPANYNAME}\UDSActorConfig.lnk" "$INSTDIR\actor_config.exe" "" ""
+
+  ExecWait 'sc create ${serviceName} error= "severe" displayname= "${displayName}" type= "own" start= "auto" binpath= "$INSTDIR\${appName}"'
+
+  WriteUninstaller $INSTDIR\uninstaller.exe
+SectionEnd
+
+Section "Uninstall"
+
+Delete $INSTDIR\uninstaller.exe
+ 
+RMDir /r $INSTDIR
+SectionEnd

--- a/.github/actor_unmanaged.nsi
+++ b/.github/actor_unmanaged.nsi
@@ -1,0 +1,33 @@
+!define VERSION 1.0.0
+
+Name "Actor Unmanaged"
+OutFile "openUDS-Unmanaged_Installer-${VERSION}.exe"
+InstallDir "$PROGRAMFILES\UDSActor"
+Page Directory
+Page InstFiles
+Section
+  SetOutPath $INSTDIR
+  File actor_client.exe
+  File actor_config_unmanaged.exe
+  File actor_service.exe  
+
+  !define COMPANYNAME "OpenUDS"
+
+  !define appName "actor_service.exe"
+  !define displayName "UDS Actor Service"
+  !define serviceName "UDSActorService"
+
+  createDirectory "$SMPROGRAMS\${COMPANYNAME}"
+  createShortCut "$SMPROGRAMS\${COMPANYNAME}\UDSActorConfig.lnk" "$INSTDIR\actor_config_unmanaged.exe" "" ""
+
+  ExecWait 'sc create ${serviceName} error= "severe" displayname= "${displayName}" type= "own" start= "auto" binpath= "$INSTDIR\${appName}"'
+
+  WriteUninstaller $INSTDIR\uninstaller.exe
+SectionEnd
+
+Section "Uninstall"
+
+Delete $INSTDIR\uninstaller.exe
+ 
+RMDir /r $INSTDIR
+SectionEnd

--- a/.github/requirements.txt
+++ b/.github/requirements.txt
@@ -1,0 +1,14 @@
+PyQt5
+psutil
+cryptography
+certifi
+altgraph
+pywin32-ctypes
+pyinstaller-hooks-contrib
+pefile
+packaging
+pyinstaller
+pywin32
+pypiwin32
+psutil
+requests

--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,0 +1,115 @@
+name: Build UDSActor exe installers
+on:
+  push:
+    branches: [ master, v4.0 ]
+  pull_request:
+    branches: [ master, v4.0 ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    defaults:
+      run:
+        shell: powershell
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r .github/requirements.txt
+
+    - name: Extract version from Python file
+      run: |
+        $lines = Get-Content src/udsactor/version.py
+        foreach ($line in $lines) {
+          if ($line -match "VERSION\s*=\s*'([\d\.]+)'") {
+            $version = $matches[1]
+            break
+          }
+        }
+        if (-not $version) {
+          throw "VERSION not found in version.py"
+        }
+        echo "VERSION=$version" >> $env:GITHUB_ENV
+
+    - name: Install NSIS
+      run: |
+        choco install nsis -y
+        echo "C:\Program Files (x86)\NSIS" >> $env:GITHUB_PATH
+
+    - name: Create PyInstaller Spec File for client
+      run: |
+        cd src
+        pyi-makespec --onefile -F --paths="c:\hostedtoolcache\windows\python\3.10.11\x64\lib\site-packages" --hidden-import=win32crypt --hidden-import=certifi --windowed actor_client.py
+
+    - name: Generate PyInstaller build for client
+      run: |
+        cd src
+        pyinstaller --noconfirm actor_client.spec
+
+    - name: Create PyInstaller Spec File for config
+      run: |
+        cd src
+        pyi-makespec --onefile -F --paths="c:\hostedtoolcache\windows\python\3.10.11\x64\lib\site-packages" --hidden-import=win32crypt --hidden-import=certifi --windowed actor_config.py
+
+    - name: Generate PyInstaller build for config
+      run: |
+        cd src
+        pyinstaller --noconfirm actor_config.spec
+
+    - name: Create PyInstaller Spec File for unmanaged config
+      run: |
+        cd src
+        pyi-makespec --onefile -F --paths="c:\hostedtoolcache\windows\python\3.10.11\x64\lib\site-packages" --hidden-import=win32crypt --hidden-import=certifi --windowed actor_config_unmanaged.py
+
+    - name: Generate PyInstaller build for unmanaged config
+      run: |
+        cd src
+        pyinstaller --noconfirm actor_config_unmanaged.spec
+
+    - name: Create PyInstaller Spec File for service
+      run: |
+        cd src
+        pyi-makespec --onefile -F --paths="c:\hostedtoolcache\windows\python\3.10.11\x64\lib\site-packages" --hidden-import=win32crypt --hidden-import=certifi --windowed actor_service.py
+
+    - name: Generate PyInstaller build for service
+      run: |
+        cd src
+        pyinstaller --noconfirm actor_service.spec
+
+    - name: Patch .nsi with version for managed actor
+      run: |
+        $nsi = Get-Content .github/actor_managed.nsi
+        $nsi = $nsi -replace '!define VERSION .*', "!define VERSION ${{ env.VERSION }}"
+        Set-Content src/dist/actor_managed.nsi $nsi
+
+    - name: Build NSIS Installer for managed actor
+      run: |
+        cd src\dist
+        makensis actor_managed.nsi
+
+    - name: Patch .nsi with version for unmanaged actor
+      run: |
+        $nsi = Get-Content .github/actor_unmanaged.nsi
+        $nsi = $nsi -replace '!define VERSION .*', "!define VERSION ${{ env.VERSION }}"
+        Set-Content src/dist/actor_unmanaged.nsi $nsi
+
+    - name: Build NSIS Installer for unmanaged actor
+      run: |
+        cd src\dist
+        makensis actor_unmanaged.nsi
+
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: UDSActor-installers-${{ env.VERSION }}-${{ github.sha }}
+        path: |
+          src\dist\openUDS-Managed_Installer-${{ env.VERSION }}.exe
+          src\dist\openUDS-Unmanaged_Installer-${{ env.VERSION }}.exe

--- a/README.md
+++ b/README.md
@@ -6,3 +6,5 @@ OpenUDS Actor
 This actor is used to connect to OpenUDS and launch a virtual machine.
 
 More info about OpenUDS: https://www.github.com/VirtualCable/openuds
+
+More info about building: https://github.com/VirtualCable/uds-client


### PR DESCRIPTION
Using GitHub Actions instead of manual build.
By accepting these commits, you can get a ready to use .exe installers for windows.
At the moment, the build will be triggered by a commit or pull request to the master or v4.0 branches. If necessary, this behavior can be changed.
I decided to use NSIS instead of WiX Toolset because it is a more flexible tool. It also allows you to create installers more easily. And also at the output we get the installers, which also has the uninstall function, which is necessary for the correct and complete removal of the program, which is not present in .the msi that was created using the readme.
And also the documentation has been slightly corrected.
