### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -1,4 +1,6 @@
 name: Build UDSActor exe installers
+permissions:
+  contents: read
 on:
   push:
     branches: [ master, v4.0 ]


### PR DESCRIPTION
Potential fix for [https://github.com/VirtualCable/uds-actor/security/code-scanning/3](https://github.com/VirtualCable/uds-actor/security/code-scanning/3)

To fix this issue, you need to explicitly add a `permissions:` block to the workflow. This block can be added at the workflow root level (top, before the `jobs:` key), so it will apply to all jobs in the workflow unless individually overridden. According to the code and steps, the workflow only checks out code and uploads artifacts, and doesn't require any write permissions on repository contents, issues, or pull requests. Therefore, you can set `contents: read` which is usually sufficient for these operations. 

Steps:
- Insert a `permissions:` block after the workflow name, before the `on:` key. 
- Set `contents: read` (the minimal required for code checkout and artifact upload).

No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
