### PR TITLE
fix: update package dependencies from policykit-1 to pkexec in udsact…

### DIFF
--- a/linux/debian/control
+++ b/linux/debian/control
@@ -10,7 +10,7 @@ Package: udsactor
 Section: admin
 Priority: optional
 Architecture: all
-Depends: policykit-1(>=0.100), python3-requests (>=0.8.2), python3-pyqt5 (>=4.9), python3 (>=3.6), libxss1, xscreensaver, ${misc:Depends}
+Depends: pkexec, python3-requests (>=0.8.2), python3-pyqt5 (>=4.9), python3 (>=3.6), libxss1, xscreensaver, ${misc:Depends}
 Recommends: python3-prctl(>=1.1.1)
 Description: Actor for Universal Desktop Services (UDS) Broker
  This package provides the required components to allow managed machines to work on an environment managed by UDS Broker.
@@ -19,7 +19,7 @@ Package: udsactor-unmanaged
 Section: admin
 Priority: optional
 Architecture: all
-Depends: policykit-1(>=0.100), python3-requests (>=0.8.2), python3-pyqt5 (>=4.9), python3 (>=3.6), libxss1, xscreensaver, ${misc:Depends}
+Depends: pkexec, python3-requests (>=0.8.2), python3-pyqt5 (>=4.9), python3 (>=3.6), libxss1, xscreensaver, ${misc:Depends}
 Recommends: python3-prctl(>=1.1.1)
 Description: Actor for Universal Desktop Services (UDS) Broker Static Unmanaged machines
  This package provides the required components to allow unmanaged machines (static, independent machines) to work on an environment managed by UDS Broker.


### PR DESCRIPTION
This pull request updates the package dependencies for both the `udsactor` and `udsactor-unmanaged` Debian packages. The main change is replacing the dependency on `policykit-1` with `pkexec`, which may affect how privilege escalation is handled.

Dependency updates:

* Replaced `policykit-1` with `pkexec` in the `Depends` list for the `udsactor` package in `linux/debian/control`.
* Replaced `policykit-1` with `pkexec` in the `Depends` list for the `udsactor-unmanaged` package in `linux/debian/control`.