### PR TITLE
fix: update package dependencies in control file for udsactor and uds…

### DIFF
--- a/building/linux/debian/control
+++ b/building/linux/debian/control
@@ -10,15 +10,15 @@ Package: udsactor
 Section: admin
 Priority: optional
 Architecture: any
-Depends: policykit-1(>=0.100), libxss1, xscreensaver, ${shlibs:Depends}, ${misc:Depends}
+Depends: pkexec, libxss1, xscreensaver, ${shlibs:Depends}, ${misc:Depends}
 Description: Actor for Universal Desktop Services (UDS) Broker
  This package provides the required components to allow managed machines to work on an environment managed by UDS Broker.
- 
+
 Package: udsactor-unmanaged
 Section: admin
 Priority: optional
 Architecture: any
-Depends: policykit-1(>=0.100), libxss1, xscreensaver, ${shlibs:Depends}, ${misc:Depends}
+Depends: pkexec, libxss1, xscreensaver, ${shlibs:Depends}, ${misc:Depends}
 Description: Actor for Universal Desktop Services (UDS) Broker Static Unmanaged machines
  This package provides the required components to allow unmanaged machines (static, independent machines) to work on an environment managed by UDS Broker.
  


### PR DESCRIPTION
This pull request updates the package dependencies for `udsactor` and `udsactor-unmanaged` in the Debian control file. The main change is replacing the dependency on `policykit-1` with `pkexec`.

Dependency updates:

* Replaced the `policykit-1` dependency with `pkexec` for both `udsactor` and `udsactor-unmanaged` packages in `building/linux/debian/control`. This may simplify or modernize privilege escalation handling.